### PR TITLE
Introduce fallback=inplace behaviour, change semantics of renderInPlace

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,8 +109,9 @@ API
 ### Portal
 
 * `@target`: required argument to specify the name of the target
-* `@renderInPlace`: by default the portal's content will not render until the target is available. 
-  If this is set to `true`, the content will be rendered in place as long as the target is not available.
+* `@fallback`: by default the portal's content will not render until the target is available. 
+  With `@fallback="inplace"` the content will be rendered in place as long as the target is not available.
+* `@renderInPlace`: if `true` the portal is effectively disabled, and the content is rendered in place.  
 
 ### PortalTarget
 

--- a/addon/components/portal.hbs
+++ b/addon/components/portal.hbs
@@ -1,4 +1,6 @@
-{{#if this.target}}
+{{#if this.renderInPlace}}
+  {{yield}}
+{{else if this.target}}
   {{#if this.target.multiple}}
     {{#in-element this.target.element insertBefore=null}}
       {{yield}}
@@ -8,6 +10,4 @@
       {{yield}}
     {{/in-element}}
   {{/if}}
-{{else if @renderInPlace}}
-  {{yield}}
 {{/if}}

--- a/addon/components/portal.js
+++ b/addon/components/portal.js
@@ -11,12 +11,16 @@ export default class PortalComponent extends Component {
     next(() => this.portalService.registerPortal(this.args.target));
   }
 
+  get target() {
+    return this.args.target && this.portalService.getTarget(this.args.target);
+  }
+
+  get renderInPlace() {
+    return this.args.renderInPlace === true || (!this.target && this.args.fallback === 'inplace');
+  }
+
   willDestroy() {
     super.willDestroy();
     next(() => this.portalService.unregisterPortal(this.args.target));
-  }
-
-  get target() {
-    return this.args.target && this.portalService.getTarget(this.args.target);
   }
 }

--- a/tests/integration/components/portal-test.js
+++ b/tests/integration/components/portal-test.js
@@ -28,15 +28,28 @@ module('Integration | Component | portal', function (hooks) {
     assert.dom('#content').doesNotExist();
   });
 
-  test('a portal without target but with renderInPlace renders in place', async function (assert) {
+  test('a portal without target but with fallback=inplace renders in place', async function (assert) {
     await render(hbs`
-      <Portal @renderInPlace={{true}}>
+      <Portal @fallback="inplace">
         <div id="content">foo</div>
       </Portal>
     `);
 
     assert.dom('#content').exists();
     assert.dom('#content').hasText('foo');
+  });
+
+  test('a portal with renderInPlace renders in place', async function (assert) {
+    await render(hbs`
+      <PortalTarget @name="main" id="portal" />
+      <Portal @target="main" @renderInPlace={{true}}>
+        <div id="content">foo</div>
+      </Portal>
+    `);
+
+    assert.dom('#content').exists();
+    assert.dom('#content').hasText('foo');
+    assert.dom('#portal #content').doesNotExist();
   });
 
   test('a portal with existing target renders in target', async function (assert) {


### PR DESCRIPTION
Makes `@renderInPlace` work like in most other solutions, i.e. in renders *always* in place. The previous fallback behaviour to render in place only as long as the target is not available is preserved using `@fallback="inplace"`.