### PR TITLE
Removed the public version of the -portal service

### DIFF
--- a/addon/components/portal-target.js
+++ b/addon/components/portal-target.js
@@ -4,7 +4,7 @@ import { inject as service } from '@ember/service';
 import { assert } from '@ember/debug';
 
 export default class PortalTargetComponent extends Component {
-  @service('-portal')
+  @service('ember-stargate@-portal')
   portalService;
 
   get count() {

--- a/addon/components/portal.js
+++ b/addon/components/portal.js
@@ -3,7 +3,7 @@ import { inject as service } from '@ember/service';
 import { next } from '@ember/runloop';
 
 export default class PortalComponent extends Component {
-  @service('-portal')
+  @service('ember-stargate@-portal')
   portalService;
 
   constructor() {

--- a/app/services/-portal.js
+++ b/app/services/-portal.js
@@ -1,1 +1,0 @@
-export { default } from 'ember-stargate/services/-portal';


### PR DESCRIPTION
Not sure you were aware you can do this, but it removes the public export of the service.   You also could remove the - in the service name, since it is no truly private.

Note you could also remove the component exports as will and change the documentation to 


`<EmberStargate@Portal>`


Also avoiding name conflicts.   

I have been moving towards this as it clearly indicates the addon the component comes from and is a good start towards template imports.

Can do another PR if you would like to see the components working in your tests as well