### PR TITLE
Register targets in the next runloop

### DIFF
--- a/packages/ember-stargate/src/services/-portal.js
+++ b/packages/ember-stargate/src/services/-portal.js
@@ -1,5 +1,6 @@
 import Service from '@ember/service';
 import { assert } from '@ember/debug';
+import { next } from '@ember/runloop';
 import { TrackedMap } from 'tracked-maps-and-sets';
 
 class TargetTracker {
@@ -29,11 +30,14 @@ export default class PortalService extends Service {
   }
 
   registerTarget(name, element, options) {
-    assert(
-      `Portal target with name ${name} already exists`,
-      !this.#targets.has(name)
-    );
-    this.#targets.set(name, new TargetTracker(name, element, options));
+    next(this, () => {
+      assert(
+        `Portal target with name ${name} already exists`,
+        !this.#targets.has(name)
+      );
+
+      this.#targets.set(name, new TargetTracker(name, element, options));
+    });
   }
 
   unregisterTarget(name) {

--- a/packages/test-app/tests/integration/components/portal-test.js
+++ b/packages/test-app/tests/integration/components/portal-test.js
@@ -119,6 +119,33 @@ module('Integration | Component | portal', function (hooks) {
     assert.dom('#content').doesNotExist();
   });
 
+  test('switching between targets with the same name', async function (assert) {
+    this.set('showPortal', true);
+
+    await render(hbs`
+      {{#if this.showPortal}}
+        <PortalTarget @name="main" id="portal" />
+      {{else}}
+        <PortalTarget @name="main" id="other-portal" />
+      {{/if}}
+
+      <Portal @target="main">
+        <div id="content">foo</div>
+      </Portal>
+    `);
+
+    assert.dom('#portal #content').exists();
+    assert.dom('#portal #content').hasText('foo');
+    assert.dom('#other-portal').doesNotExist();
+
+    this.set('showPortal', false);
+    await settled();
+
+    assert.dom('#other-portal #content').exists();
+    assert.dom('#other-portal #content').hasText('foo');
+    assert.dom('#portal').doesNotExist();
+  });
+
   test('switching the target moves existing content', async function (assert) {
     this.set('target', 'p1');
     await render(hbs`


### PR DESCRIPTION
When reusing the same portal target name between condition branches (or routes) there has to be enough time for the previous target to get cleaned up before registering the new target.

This fixes #24